### PR TITLE
feat: optimize warp animations across site pages

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -8,20 +8,34 @@ const {
   title,
   description,
   showNavigation = true,
-  useInfoLayout = false
+  useInfoLayout = false,
+  useContentLayout = false
 } = Astro.props;
 ---
 
 <RootLayout title={title} description={description}>
-  {showNavigation && !useInfoLayout && (
+  {showNavigation && !useInfoLayout && !useContentLayout && (
     <TopNavigation client:load />
     <div class="h-16"></div> <!-- Spacer for fixed nav -->
   )}
 
-  {useInfoLayout ? (
+  {useContentLayout ? (
+    <!-- Content-focused layout without warp animation for better readability -->
+    <div class="bg-black min-h-screen">
+      {showNavigation && (
+        <TopNavigation variant="static" client:load />
+      )}
+      <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="[&_h1]:text-red-600 pt-8 pb-20 text-white">
+          <slot />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  ) : useInfoLayout ? (
     <div class="flex relative gap-4 w-full max-w-screen-xl">
-      <nav class="relative w-4 md:min-w-[18rem] xl:min-w-[24rem] sm:min-h-screen sm:ml-4 sm:pb-4">
-        <div class="w-full h-full max-sm:w-4 md:max-w-[18rem] xl:max-w-[24rem] fixed -z-10 sm:bottom-4 sm:rounded-b-full overflow-hidden">
+      <nav class="relative w-4 md:min-w-[12rem] xl:min-w-[16rem] sm:min-h-screen sm:ml-4 sm:pb-4">
+        <div class="w-full h-full max-sm:w-4 md:max-w-[12rem] xl:max-w-[16rem] fixed -z-10 sm:bottom-4 sm:rounded-b-full overflow-hidden">
           <WarpBackground
             color1="#fca5a5"
             color2="#ef4444"

--- a/src/pages/what-we-do/ai-hackathon/index.astro
+++ b/src/pages/what-we-do/ai-hackathon/index.astro
@@ -5,7 +5,7 @@ import GoogleForm from "../../../components/forms/GoogleForm";
 import { FORMS } from "../../../config/forms";
 ---
 
-<PageLayout title="AI Hackathon - Sinthome" useInfoLayout={true}>
+<PageLayout title="AI Hackathon - Sinthome" useContentLayout={true}>
     <H1>AI Hackathon</H1>
 
     <div class="space-y-8 max-w-4xl">

--- a/src/pages/what-we-do/plantcore-ai.astro
+++ b/src/pages/what-we-do/plantcore-ai.astro
@@ -9,7 +9,7 @@ import { Image } from 'astro:assets';
 import factoryImage from "../../assets/plantcore-ai/factory.png";
 ---
 
-<PageLayout title="Plantcore.AI - Sinthome" useInfoLayout={true}>
+<PageLayout title="Plantcore.AI - Sinthome" useContentLayout={true}>
     <H1>Plantcore.AI</H1>
 
     <div class="space-y-8 max-w-4xl">

--- a/src/pages/what-we-do/srtp.astro
+++ b/src/pages/what-we-do/srtp.astro
@@ -129,7 +129,7 @@ import H1 from "../../components/ui/H1.astro";
   }
 </style>
 
-<PageLayout title="S.R.T.P. - Sinthome" useInfoLayout={true}>
+<PageLayout title="S.R.T.P. - Sinthome" useContentLayout={true}>
     <!-- Enhanced Title Structure -->
     <div class="text-center mb-12">
       <h1 class="text-6xl font-bold text-white mb-4 tracking-wider">S.R.T.P.</h1>

--- a/src/pages/what-we-do/workers-assist.astro
+++ b/src/pages/what-we-do/workers-assist.astro
@@ -8,7 +8,7 @@ import communityPhoto from "../../assets/workers-assist/合影.jpg";
 import picnicPhoto from "../../assets/workers-assist/野餐.jpg";
 ---
 
-<PageLayout title="Workers Assist - Sinthome" useInfoLayout={true}>
+<PageLayout title="Workers Assist - Sinthome" useContentLayout={true}>
     <H1>Workers Assist</H1>
 
     <div class="space-y-8 max-w-4xl">


### PR DESCRIPTION
- Removed warp animations from What We Do content pages:
  - AI Hackathon: useContentLayout for distraction-free reading
  - Plantcore AI: useContentLayout for focused content
  - Workers Assist: useContentLayout for better engagement
  - S.R.T.P.: useContentLayout for academic content clarity

- Reduced warp animation width on info pages (33% reduction):
  - Medium screens: 18rem → 12rem (saves 96px for content)
  - XL screens: 24rem → 16rem (saves 128px for content)
  - Maintains visual interest with better content space

- Benefits:
  - Improved reading experience on content-heavy pages
  - Better mobile experience with more content space
  - Enhanced accessibility for motion-sensitive users
  - Maintained brand identity across all layouts

Based on UI/UX designer recommendations for optimal content focus