### PR TITLE
Remove flowing background graphics from project pages

### DIFF
--- a/src/pages/what-we-do/ai-hackathon/index.astro
+++ b/src/pages/what-we-do/ai-hackathon/index.astro
@@ -5,10 +5,10 @@ import GoogleForm from "../../../components/forms/GoogleForm";
 import { FORMS } from "../../../config/forms";
 ---
 
-<PageLayout title="AI Hackathon - Sinthome" useInfoLayout={true}>
+<PageLayout title="AI Hackathon - Sinthome" useInfoLayout={false}>
     <H1>AI Hackathon</H1>
 
-    <div class="space-y-8 max-w-4xl">
+    <div class="space-y-8 max-w-4xl mx-auto px-4">
       <!-- Overview -->
       <section>
         <h2 class="text-2xl font-bold text-white mb-4">AI NGO & Hackathon</h2>

--- a/src/pages/what-we-do/plantcore-ai.astro
+++ b/src/pages/what-we-do/plantcore-ai.astro
@@ -9,10 +9,10 @@ import { Image } from 'astro:assets';
 import factoryImage from "../../assets/plantcore-ai/factory.png";
 ---
 
-<PageLayout title="Plantcore.AI - Sinthome" useInfoLayout={true}>
+<PageLayout title="Plantcore.AI - Sinthome" useInfoLayout={false}>
     <H1>Plantcore.AI</H1>
 
-    <div class="space-y-8 max-w-4xl">
+    <div class="space-y-8 max-w-4xl mx-auto px-4">
       <!-- Mission -->
       <section>
         <h2 class="text-2xl font-bold text-white mb-4">Mission — Reshaping the Future of Industry</h2>

--- a/src/pages/what-we-do/srtp.astro
+++ b/src/pages/what-we-do/srtp.astro
@@ -129,7 +129,7 @@ import H1 from "../../components/ui/H1.astro";
   }
 </style>
 
-<PageLayout title="S.R.T.P. - Sinthome" useInfoLayout={true}>
+<PageLayout title="S.R.T.P. - Sinthome" useInfoLayout={false}>
     <!-- Enhanced Title Structure -->
     <div class="text-center mb-12">
       <h1 class="text-6xl font-bold text-white mb-4 tracking-wider">S.R.T.P.</h1>
@@ -137,7 +137,7 @@ import H1 from "../../components/ui/H1.astro";
       <div class="w-32 h-1 bg-gradient-to-r from-red-600 to-red-800 mx-auto mt-6"></div>
     </div>
 
-    <div class="space-y-16 max-w-4xl">
+    <div class="space-y-16 max-w-4xl mx-auto px-4">
       <!-- Overview -->
       <section>
         <h3 class="text-2xl font-bold text-white mb-8 text-center">Interrogating praxis, until it unveils the future.</h3>

--- a/src/pages/what-we-do/workers-assist.astro
+++ b/src/pages/what-we-do/workers-assist.astro
@@ -8,10 +8,10 @@ import communityPhoto from "../../assets/workers-assist/合影.jpg";
 import picnicPhoto from "../../assets/workers-assist/野餐.jpg";
 ---
 
-<PageLayout title="Workers Assist - Sinthome" useInfoLayout={true}>
+<PageLayout title="Workers Assist - Sinthome" useInfoLayout={false}>
     <H1>Workers Assist</H1>
 
-    <div class="space-y-8 max-w-4xl">
+    <div class="space-y-8 max-w-4xl mx-auto px-4">
       <!-- Hero Section -->
       <section class="text-center mb-12">
         <h2 class="text-4xl font-bold text-white mb-2">


### PR DESCRIPTION
- Remove WarpBackground from ai-hackathon, workers-assist, plantcore-ai, and srtp pages
- Set useInfoLayout to false for these four project pages
- Add center alignment (mx-auto px-4) for better content layout