### PR TITLE
feat: enhance warp animation to bookmark-style design

### DIFF
--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -34,16 +34,20 @@ const {
     </div>
   ) : useInfoLayout ? (
     <div class="flex relative gap-4 w-full max-w-screen-xl">
-      <nav class="relative w-4 md:min-w-[12rem] xl:min-w-[16rem] sm:min-h-screen sm:ml-4 sm:pb-4">
-        <div class="w-full h-full max-sm:w-4 md:max-w-[12rem] xl:max-w-[16rem] fixed -z-10 sm:bottom-4 sm:rounded-b-full overflow-hidden">
+      <!-- Bookmark-style warp animation -->
+      <nav class="relative w-4 md:min-w-[4rem] xl:min-w-[5rem] sm:min-h-screen sm:ml-8 sm:pb-4">
+        <div class="w-full h-[80vh] max-sm:w-4 md:max-w-[3rem] xl:max-w-[4rem] fixed top-[10vh] -z-10 sm:rounded-full overflow-hidden shadow-2xl">
           <WarpBackground
-            color1="#fca5a5"
-            color2="#ef4444"
-            color3="#b91c1c"
+            color1="#000000"
+            color2="#940000"
+            color3="#000000"
             speed={0.15}
-            swirl={1.5}
-            swirlIterations={10}
-            shapeScale={0.3}
+            swirl={0.98}
+            swirlIterations={20}
+            shapeScale={0.08}
+            rotation={0.55}
+            scale={0.3}
+            softness={0}
             client:load
           />
         </div>


### PR DESCRIPTION
- Reduce warp animation height to 80% of viewport height
- Add left padding (sm:ml-8) for better spacing
- Make warp thinner (3-4rem width) for bookmark appearance
- Position at 10% from top with 80vh height for balanced look
- Update colors to match main homepage animation (#000000, #940000)
- Add parameters for sharper, more defined animation
- Apply rounded-full styling with shadow for depth