### PR TITLE
fix: remove non-functional Contact Us button on Workers Assist page

### DIFF
--- a/src/pages/what-we-do/workers-assist.astro
+++ b/src/pages/what-we-do/workers-assist.astro
@@ -276,7 +276,7 @@ import picnicPhoto from "../../assets/workers-assist/野餐.jpg";
         <p class="text-lg text-zinc-300 mb-8">
           Join English class and youth program participation as student, please contact:
         </p>
-        <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <div class="flex justify-center">
           <a
             href="tel:+18578331708"
             class="inline-flex items-center gap-2 px-8 py-4 bg-red-600 text-white font-bold rounded-lg hover:bg-red-700 transition-colors duration-300 transform hover:scale-105"
@@ -285,12 +285,6 @@ import picnicPhoto from "../../assets/workers-assist/野餐.jpg";
               <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z"/>
             </svg>
             +1 857-833-1708
-          </a>
-          <a
-            href="#contact"
-            class="inline-flex items-center gap-2 px-8 py-4 bg-transparent border-2 border-red-600 text-red-400 font-bold rounded-lg hover:bg-red-600 hover:text-white transition-all duration-300"
-          >
-            Contact Us
           </a>
         </div>
       </div>


### PR DESCRIPTION
- Remove Contact Us button that linked to non-existent #contact anchor
- Center the phone number button for better visual balance
- Simplify UI by keeping only the functional phone contact method

Closes #56